### PR TITLE
Add protocol timer component

### DIFF
--- a/src/app/switch/[step]/page.tsx
+++ b/src/app/switch/[step]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import ProtocolTimer from "./protocol-timer";
 
 const STEPS = [
   {
@@ -76,7 +77,7 @@ export default async function StepPage({
         <h1 className="text-2xl font-bold">{step.title}</h1>
         <p className="mt-2 text-gray-600">{step.description}</p>
         <div className="mt-6 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8 text-center text-sm text-gray-400">
-          {step.placeholder}
+          {stepNum === 3 ? <ProtocolTimer /> : step.placeholder}
         </div>
       </section>
 

--- a/src/app/switch/[step]/protocol-timer.tsx
+++ b/src/app/switch/[step]/protocol-timer.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+const TOTAL_SECONDS = 2 * 60;
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+export default function ProtocolTimer() {
+  const [remaining, setRemaining] = useState(TOTAL_SECONDS);
+  const [running, setRunning] = useState(false);
+  const [complete, setComplete] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!running) {
+      clearTimer();
+      return;
+    }
+
+    intervalRef.current = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1) {
+          setRunning(false);
+          setComplete(true);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return clearTimer;
+  }, [running, clearTimer]);
+
+  const handleStart = () => {
+    if (!complete) setRunning(true);
+  };
+
+  const handlePause = () => {
+    setRunning(false);
+  };
+
+  const handleReset = () => {
+    setRunning(false);
+    setComplete(false);
+    setRemaining(TOTAL_SECONDS);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      {/* Timer display */}
+      <div
+        className={`font-mono text-5xl font-bold tabular-nums ${
+          complete ? "text-green-600" : "text-gray-900"
+        }`}
+        aria-live="polite"
+        role="timer"
+      >
+        {formatTime(remaining)}
+      </div>
+
+      {/* Status */}
+      {complete && (
+        <p className="text-sm font-medium text-green-600">
+          Complete — protocol time is up.
+        </p>
+      )}
+
+      {/* Controls */}
+      <div className="flex gap-3">
+        {!running && !complete && (
+          <button
+            onClick={handleStart}
+            className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+          >
+            {remaining < TOTAL_SECONDS ? "Resume" : "Start"}
+          </button>
+        )}
+
+        {running && (
+          <button
+            onClick={handlePause}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Pause
+          </button>
+        )}
+
+        <button
+          onClick={handleReset}
+          className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a 2-minute countdown timer to the Protocol step (`/switch/3`)
- Controls: Start, Pause, Reset
- Shows "Complete" state when timer reaches 0:00, disabling Start until Reset
- Pure React state/hooks, no extra dependencies

Closes #5

## Test plan
- [ ] `npm run build` passes
- [ ] Navigate `/switch` -> `/switch/1` -> `/switch/2` -> `/switch/3`
- [ ] Timer displays `02:00` initially
- [ ] Click **Start** — timer counts down each second
- [ ] Click **Pause** — timer stops; button changes to **Resume**
- [ ] Click **Resume** — timer continues from paused time
- [ ] Click **Reset** — timer returns to `02:00`, Start re-enabled
- [ ] Let timer reach `00:00` — displays green "Complete" text, Start hidden
- [ ] Click **Reset** after completion — timer returns to `02:00`, Start re-enabled
- [ ] Steps 1 and 2 still show their placeholder text (no timer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)