### PR TITLE
Add before/after ratings with local storage

### DIFF
--- a/src/app/switch/[step]/page.tsx
+++ b/src/app/switch/[step]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import ProtocolTimer from "./protocol-timer";
+import RatingInput from "./rating-input";
 
 const STEPS = [
   {
@@ -77,7 +78,16 @@ export default async function StepPage({
         <h1 className="text-2xl font-bold">{step.title}</h1>
         <p className="mt-2 text-gray-600">{step.description}</p>
         <div className="mt-6 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8 text-center text-sm text-gray-400">
-          {stepNum === 3 ? <ProtocolTimer /> : step.placeholder}
+          {stepNum === 1 && (
+            <RatingInput kind="before" label="How do you feel right now? (before)" />
+          )}
+          {stepNum === 2 && step.placeholder}
+          {stepNum === 3 && (
+            <div className="flex flex-col gap-8">
+              <ProtocolTimer />
+              <RatingInput kind="after" label="How do you feel now? (after)" />
+            </div>
+          )}
         </div>
       </section>
 

--- a/src/app/switch/[step]/rating-input.tsx
+++ b/src/app/switch/[step]/rating-input.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getRating, setRating, type RatingKind } from "@/lib/ratings";
+
+export default function RatingInput({
+  kind,
+  label,
+}: {
+  kind: RatingKind;
+  label: string;
+}) {
+  const [value, setValue] = useState<number | null>(null);
+
+  useEffect(() => {
+    setValue(getRating(kind));
+  }, [kind]);
+
+  function handleSelect(n: number) {
+    setValue(n);
+    setRating(kind, n);
+  }
+
+  return (
+    <fieldset className="flex flex-col items-center gap-3">
+      <legend className="text-sm font-medium text-gray-700">{label}</legend>
+      <div className="flex gap-1.5">
+        {Array.from({ length: 11 }, (_, i) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => handleSelect(i)}
+            className={`h-9 w-9 rounded-md text-sm font-medium transition-colors ${
+              value === i
+                ? "bg-gray-900 text-white"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+            }`}
+          >
+            {i}
+          </button>
+        ))}
+      </div>
+      <span className="flex gap-4 text-xs text-gray-400">
+        <span>0 = low</span>
+        <span>10 = high</span>
+      </span>
+    </fieldset>
+  );
+}

--- a/src/lib/ratings.ts
+++ b/src/lib/ratings.ts
@@ -1,0 +1,33 @@
+const STORAGE_KEY = "2ms-ratings";
+
+export type RatingKind = "before" | "after";
+
+interface Ratings {
+  before: number | null;
+  after: number | null;
+}
+
+function read(): Ratings {
+  if (typeof window === "undefined") return { before: null, after: null };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { before: null, after: null };
+    const parsed = JSON.parse(raw);
+    return {
+      before: typeof parsed.before === "number" ? parsed.before : null,
+      after: typeof parsed.after === "number" ? parsed.after : null,
+    };
+  } catch {
+    return { before: null, after: null };
+  }
+}
+
+export function getRating(kind: RatingKind): number | null {
+  return read()[kind];
+}
+
+export function setRating(kind: RatingKind, value: number): void {
+  const ratings = read();
+  ratings[kind] = value;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(ratings));
+}


### PR DESCRIPTION
## Summary
- Add "Before" rating (0–10) on `/switch/1` (Context step)
- Add "After" rating (0–10) on `/switch/3` (Protocol step)
- Persist ratings in `localStorage` across refresh and navigation
- Shared storage helpers in `src/lib/ratings.ts`

Closes #6

## Test plan
- [ ] Go to `/switch/1` → select a Before rating (e.g. 7) → value highlights
- [ ] Navigate to `/switch/2` → navigate to `/switch/3` → select After rating (e.g. 4)
- [ ] Refresh page → both ratings persist
- [ ] Change a rating → refresh → new value persists
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)