### PR TITLE
Add basic analytics event logging

### DIFF
--- a/src/app/switch/[step]/page.tsx
+++ b/src/app/switch/[step]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import ProtocolTimer from "./protocol-timer";
 import RatingInput from "./rating-input";
+import StepTracker from "./step-tracker";
 
 const STEPS = [
   {
@@ -51,6 +52,7 @@ export default async function StepPage({
 
   return (
     <div className="flex flex-col gap-8">
+      <StepTracker step={stepNum} />
       {/* Progress indicator */}
       <nav aria-label="Step progress" className="flex items-center gap-2">
         {STEPS.map((s) => (

--- a/src/app/switch/[step]/protocol-timer.tsx
+++ b/src/app/switch/[step]/protocol-timer.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { logEvent } from "@/lib/analytics";
+import { logError } from "@/lib/error";
 
 const TOTAL_SECONDS = 2 * 60;
 
@@ -34,6 +36,7 @@ export default function ProtocolTimer() {
         if (prev <= 1) {
           setRunning(false);
           setComplete(true);
+          logEvent("timer_complete");
           return 0;
         }
         return prev - 1;
@@ -44,17 +47,34 @@ export default function ProtocolTimer() {
   }, [running, clearTimer]);
 
   const handleStart = () => {
-    if (!complete) setRunning(true);
+    try {
+      if (!complete) {
+        setRunning(true);
+        logEvent("timer_start");
+      }
+    } catch (err) {
+      logError("ProtocolTimer.handleStart", err);
+    }
   };
 
   const handlePause = () => {
-    setRunning(false);
+    try {
+      setRunning(false);
+      logEvent("timer_pause");
+    } catch (err) {
+      logError("ProtocolTimer.handlePause", err);
+    }
   };
 
   const handleReset = () => {
-    setRunning(false);
-    setComplete(false);
-    setRemaining(TOTAL_SECONDS);
+    try {
+      setRunning(false);
+      setComplete(false);
+      setRemaining(TOTAL_SECONDS);
+      logEvent("timer_reset");
+    } catch (err) {
+      logError("ProtocolTimer.handleReset", err);
+    }
   };
 
   return (

--- a/src/app/switch/[step]/rating-input.tsx
+++ b/src/app/switch/[step]/rating-input.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { getRating, setRating, type RatingKind } from "@/lib/ratings";
+import { logEvent } from "@/lib/analytics";
+import { logError } from "@/lib/error";
 
 export default function RatingInput({
   kind,
@@ -17,8 +19,15 @@ export default function RatingInput({
   }, [kind]);
 
   function handleSelect(n: number) {
-    setValue(n);
-    setRating(kind, n);
+    try {
+      setValue(n);
+      setRating(kind, n);
+      logEvent(kind === "before" ? "before_rating_set" : "after_rating_set", {
+        value: n,
+      });
+    } catch (err) {
+      logError("RatingInput.handleSelect", err);
+    }
   }
 
   return (

--- a/src/app/switch/[step]/step-tracker.tsx
+++ b/src/app/switch/[step]/step-tracker.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+import { logEvent } from "@/lib/analytics";
+
+export default function StepTracker({ step }: { step: number }) {
+  useEffect(() => {
+    logEvent("step_view", { step });
+    if (step === 1) {
+      logEvent("session_start");
+    }
+  }, [step]);
+
+  return null;
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,16 @@
+type EventName =
+  | "session_start"
+  | "step_view"
+  | "before_rating_set"
+  | "after_rating_set"
+  | "timer_start"
+  | "timer_pause"
+  | "timer_reset"
+  | "timer_complete";
+
+export function logEvent(
+  name: EventName,
+  data?: Record<string, unknown>,
+): void {
+  console.log(`[analytics] ${name}`, data ?? "");
+}

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,0 +1,3 @@
+export function logError(context: string, error: unknown): void {
+  console.error(`[error] ${context}`, error);
+}


### PR DESCRIPTION
## Summary
- Add `src/lib/analytics.ts` — tiny `logEvent()` utility that logs to `console.log`
- Add `src/lib/error.ts` — tiny `logError()` utility that logs to `console.error`
- Track events: `session_start`, `step_view`, `before_rating_set`, `after_rating_set`, `timer_start`, `timer_pause`, `timer_reset`, `timer_complete`
- Wrap critical client handlers with try/catch → `logError`

Closes #11

## Test plan
- [ ] Go to `/switch/1` → console shows `session_start` and `step_view {step: 1}`
- [ ] Select a Before rating → console shows `before_rating_set {value: N}`
- [ ] Navigate to `/switch/2` → console shows `step_view {step: 2}`
- [ ] Navigate to `/switch/3` → console shows `step_view {step: 3}`
- [ ] Select an After rating → console shows `after_rating_set {value: N}`
- [ ] Click Start on timer → console shows `timer_start`
- [ ] Click Pause → console shows `timer_pause`
- [ ] Click Reset → console shows `timer_reset`
- [ ] Let timer run to 0:00 → console shows `timer_complete`
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)