### PR TITLE
Add protocol library v1

### DIFF
--- a/src/app/switch/[step]/page.tsx
+++ b/src/app/switch/[step]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import ProtocolTimer from "./protocol-timer";
 import RatingInput from "./rating-input";
+import ProtocolStep from "./protocol-step";
 import StepTracker from "./step-tracker";
 
 const STEPS = [
@@ -84,12 +84,7 @@ export default async function StepPage({
             <RatingInput kind="before" label="How do you feel right now? (before)" />
           )}
           {stepNum === 2 && step.placeholder}
-          {stepNum === 3 && (
-            <div className="flex flex-col gap-8">
-              <ProtocolTimer />
-              <RatingInput kind="after" label="How do you feel now? (after)" />
-            </div>
-          )}
+          {stepNum === 3 && <ProtocolStep />}
         </div>
       </section>
 

--- a/src/app/switch/[step]/protocol-picker.tsx
+++ b/src/app/switch/[step]/protocol-picker.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import {
+  PROTOCOLS,
+  ALL_CATEGORIES,
+  CATEGORY_LABELS,
+  type Protocol,
+  type ProtocolCategory,
+} from "@/lib/protocols";
+import { logEvent } from "@/lib/analytics";
+
+export default function ProtocolPicker({
+  selected,
+  onSelect,
+}: {
+  selected: Protocol | null;
+  onSelect: (protocol: Protocol) => void;
+}) {
+  const [filter, setFilter] = useState<ProtocolCategory | "all">("all");
+
+  const visible =
+    filter === "all"
+      ? PROTOCOLS
+      : PROTOCOLS.filter((p) => p.category === filter);
+
+  function handleSelect(protocol: Protocol) {
+    onSelect(protocol);
+    logEvent("protocol_selected", { protocolId: protocol.id });
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Category filter */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={() => setFilter("all")}
+          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+            filter === "all"
+              ? "bg-gray-900 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+          }`}
+        >
+          All
+        </button>
+        {ALL_CATEGORIES.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setFilter(cat)}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              filter === cat
+                ? "bg-gray-900 text-white"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+            }`}
+          >
+            {CATEGORY_LABELS[cat]}
+          </button>
+        ))}
+      </div>
+
+      {/* Protocol grid */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {visible.map((p) => {
+          const isSelected = selected?.id === p.id;
+          return (
+            <button
+              key={p.id}
+              onClick={() => handleSelect(p)}
+              className={`rounded-lg border p-3 text-left transition-colors ${
+                isSelected
+                  ? "border-gray-900 bg-gray-900 text-white"
+                  : "border-gray-200 bg-white hover:border-gray-400"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <span
+                  className={`text-sm font-semibold ${isSelected ? "text-white" : "text-gray-900"}`}
+                >
+                  {p.title}
+                </span>
+                <span
+                  className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                    isSelected
+                      ? "bg-white/20 text-white"
+                      : "bg-gray-100 text-gray-500"
+                  }`}
+                >
+                  {CATEGORY_LABELS[p.category]}
+                </span>
+              </div>
+              <p
+                className={`mt-1 text-xs leading-relaxed ${isSelected ? "text-gray-300" : "text-gray-500"}`}
+              >
+                {p.summary}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/switch/[step]/protocol-step.tsx
+++ b/src/app/switch/[step]/protocol-step.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import type { Protocol } from "@/lib/protocols";
+import ProtocolPicker from "./protocol-picker";
+import ProtocolTimer from "./protocol-timer";
+import RatingInput from "./rating-input";
+
+export default function ProtocolStep() {
+  const [selected, setSelected] = useState<Protocol | null>(null);
+
+  return (
+    <div className="flex flex-col gap-8">
+      {/* Protocol selection */}
+      <div>
+        <h2 className="mb-3 text-sm font-semibold text-gray-700">
+          Choose a protocol
+        </h2>
+        <ProtocolPicker selected={selected} onSelect={setSelected} />
+      </div>
+
+      {/* Timer + steps (shown after picking a protocol) */}
+      {selected && (
+        <>
+          <div className="rounded-lg border border-gray-200 bg-white p-6">
+            <h3 className="text-lg font-bold text-gray-900">
+              {selected.title}
+            </h3>
+            <p className="mt-1 text-sm text-gray-500">{selected.summary}</p>
+            <ol className="mt-4 list-inside list-decimal space-y-2 text-sm text-gray-700">
+              {selected.steps.map((s, i) => (
+                <li key={i}>{s}</li>
+              ))}
+            </ol>
+          </div>
+
+          <ProtocolTimer />
+
+          <RatingInput kind="after" label="How do you feel now? (after)" />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -6,7 +6,8 @@ type EventName =
   | "timer_start"
   | "timer_pause"
   | "timer_reset"
-  | "timer_complete";
+  | "timer_complete"
+  | "protocol_selected";
 
 export function logEvent(
   name: EventName,

--- a/src/lib/protocols.ts
+++ b/src/lib/protocols.ts
@@ -1,0 +1,274 @@
+export interface Protocol {
+  id: string;
+  title: string;
+  category: ProtocolCategory;
+  durationLabel: string;
+  summary: string;
+  steps: string[];
+}
+
+export type ProtocolCategory =
+  | "breathing"
+  | "movement"
+  | "mindset"
+  | "sensory"
+  | "social";
+
+export const CATEGORY_LABELS: Record<ProtocolCategory, string> = {
+  breathing: "Breathing",
+  movement: "Movement",
+  mindset: "Mindset",
+  sensory: "Sensory",
+  social: "Social",
+};
+
+export const PROTOCOLS: Protocol[] = [
+  // --- Breathing ---
+  {
+    id: "box-breathing",
+    title: "Box Breathing",
+    category: "breathing",
+    durationLabel: "2 min",
+    summary: "Inhale, hold, exhale, hold — each for 4 seconds.",
+    steps: [
+      "Sit upright and exhale fully.",
+      "Inhale through your nose for 4 seconds.",
+      "Hold your breath for 4 seconds.",
+      "Exhale slowly through your mouth for 4 seconds.",
+      "Hold empty for 4 seconds.",
+      "Repeat the cycle for the full 2 minutes.",
+    ],
+  },
+  {
+    id: "4-7-8-breathing",
+    title: "4-7-8 Breathing",
+    category: "breathing",
+    durationLabel: "2 min",
+    summary: "Calming breath pattern to activate your rest response.",
+    steps: [
+      "Place the tip of your tongue behind your upper front teeth.",
+      "Exhale completely through your mouth.",
+      "Inhale quietly through your nose for 4 seconds.",
+      "Hold your breath for 7 seconds.",
+      "Exhale through your mouth for 8 seconds.",
+      "Repeat for the full 2 minutes.",
+    ],
+  },
+  {
+    id: "energizing-breath",
+    title: "Energizing Breath",
+    category: "breathing",
+    durationLabel: "2 min",
+    summary: "Quick, rhythmic breathing to boost alertness.",
+    steps: [
+      "Sit tall with your spine straight.",
+      "Take a sharp inhale through your nose.",
+      "Follow with a forceful exhale through your nose.",
+      "Keep breaths short and equal in duration.",
+      "Maintain a steady rhythm of about 2–3 cycles per second.",
+      "Pause after 30 seconds, breathe normally, then repeat.",
+    ],
+  },
+  // --- Movement ---
+  {
+    id: "desk-stretch",
+    title: "Desk Stretch",
+    category: "movement",
+    durationLabel: "2 min",
+    summary: "Quick stretches you can do without leaving your chair.",
+    steps: [
+      "Roll your shoulders backward 5 times, then forward 5 times.",
+      "Interlace your fingers and push palms to the ceiling for 15 seconds.",
+      "Turn your head slowly left, hold 10 seconds, then right.",
+      "Cross one arm over your chest, hold 10 seconds, switch.",
+      "Rotate your wrists 10 times in each direction.",
+      "Take three deep breaths to finish.",
+    ],
+  },
+  {
+    id: "body-shake",
+    title: "Body Shake-Off",
+    category: "movement",
+    durationLabel: "2 min",
+    summary: "Shake out tension from head to toe.",
+    steps: [
+      "Stand up and find a small space to move.",
+      "Shake your hands vigorously for 20 seconds.",
+      "Add your arms, letting them flop loosely.",
+      "Bounce on your toes and shake your legs one at a time.",
+      "Shake your whole body freely for 30 seconds.",
+      "Slow down gradually and stand still; notice the calm.",
+    ],
+  },
+  {
+    id: "walking-reset",
+    title: "Walking Reset",
+    category: "movement",
+    durationLabel: "2 min",
+    summary: "A brief mindful walk to shift your state.",
+    steps: [
+      "Stand up and begin walking at a slow pace.",
+      "Focus on the sensation of each foot touching the ground.",
+      "Breathe naturally and let your arms swing freely.",
+      "After 1 minute, pause and notice how your body feels.",
+      "Resume walking for the remaining time.",
+      "Return to your seat with intention.",
+    ],
+  },
+  // --- Mindset ---
+  {
+    id: "intention-set",
+    title: "Intention Setting",
+    category: "mindset",
+    durationLabel: "2 min",
+    summary: "Clarify one clear intention for the next task.",
+    steps: [
+      "Close your eyes and take 3 slow breaths.",
+      "Ask yourself: what is the single most important outcome?",
+      "Formulate a short, specific intention in one sentence.",
+      "Repeat the intention silently three times.",
+      "Visualize yourself completing the task successfully.",
+      "Open your eyes and write the intention down if possible.",
+    ],
+  },
+  {
+    id: "gratitude-pause",
+    title: "Gratitude Pause",
+    category: "mindset",
+    durationLabel: "2 min",
+    summary: "Name three things you are grateful for right now.",
+    steps: [
+      "Sit quietly and close your eyes.",
+      "Think of one person you are grateful for — picture them.",
+      "Think of one thing that went well today, however small.",
+      "Think of one ability or resource you have access to.",
+      "Hold all three in mind and notice how it feels.",
+      "Open your eyes and carry that feeling forward.",
+    ],
+  },
+  {
+    id: "mental-rehearsal",
+    title: "Mental Rehearsal",
+    category: "mindset",
+    durationLabel: "2 min",
+    summary: "Walk through your next task step by step in your mind.",
+    steps: [
+      "Close your eyes and take two deep breaths.",
+      "Picture the environment where you will do the next task.",
+      "Visualize yourself starting the task confidently.",
+      "Imagine handling the most challenging part smoothly.",
+      "See yourself completing it and feeling satisfied.",
+      "Open your eyes, ready to begin.",
+    ],
+  },
+  // --- Sensory ---
+  {
+    id: "5-4-3-2-1",
+    title: "5-4-3-2-1 Grounding",
+    category: "sensory",
+    durationLabel: "2 min",
+    summary: "Use your five senses to ground into the present.",
+    steps: [
+      "Notice 5 things you can see — name them silently.",
+      "Notice 4 things you can touch — feel each one.",
+      "Notice 3 things you can hear — listen carefully.",
+      "Notice 2 things you can smell — or imagine smells.",
+      "Notice 1 thing you can taste — savor it.",
+      "Take a deep breath and return your focus.",
+    ],
+  },
+  {
+    id: "cold-water-reset",
+    title: "Cold Water Reset",
+    category: "sensory",
+    durationLabel: "2 min",
+    summary: "Use cold water on your face/wrists to sharpen focus.",
+    steps: [
+      "Go to the nearest sink.",
+      "Run cold water over your wrists for 15 seconds.",
+      "Splash cold water on your face 3–4 times.",
+      "Pat dry with a towel and notice the sensation.",
+      "Take 3 slow breaths while standing still.",
+      "Return to your workspace feeling refreshed.",
+    ],
+  },
+  {
+    id: "music-shift",
+    title: "Music Shift",
+    category: "sensory",
+    durationLabel: "2 min",
+    summary: "Listen to one song that matches your desired state.",
+    steps: [
+      "Choose a song that matches the energy you want next.",
+      "Put on headphones and press play.",
+      "Close your eyes and focus only on the music.",
+      "Let the rhythm influence your breathing and posture.",
+      "When the 2 minutes end, carry that energy forward.",
+      "Remove headphones and transition to your next task.",
+    ],
+  },
+  // --- Social ---
+  {
+    id: "check-in-call",
+    title: "Quick Check-In",
+    category: "social",
+    durationLabel: "2 min",
+    summary: "Send a brief message or text to someone you care about.",
+    steps: [
+      "Think of one person you have not spoken to today.",
+      "Open your messaging app or phone.",
+      "Send a short, genuine message — just 1–2 sentences.",
+      "Put the phone down; do not wait for a reply.",
+      "Notice how reaching out made you feel.",
+      "Shift your attention to the next task.",
+    ],
+  },
+  {
+    id: "compliment-drop",
+    title: "Compliment Drop",
+    category: "social",
+    durationLabel: "2 min",
+    summary: "Give a genuine compliment to someone nearby or online.",
+    steps: [
+      "Think of someone who did something helpful recently.",
+      "Craft a specific, genuine compliment (not generic).",
+      "Deliver it — in person, via chat, or email.",
+      "Do not expect anything in return.",
+      "Take a breath and notice how giving feels.",
+      "Move on to your next task.",
+    ],
+  },
+  {
+    id: "boundary-set",
+    title: "Boundary Setting",
+    category: "social",
+    durationLabel: "2 min",
+    summary: "Mentally define one boundary for the next work block.",
+    steps: [
+      "Close your eyes and take a deep breath.",
+      "Identify one thing that drained your energy recently.",
+      "Decide on one clear boundary — what you will say no to.",
+      "Phrase it simply: 'During the next block I will not…'",
+      "Commit to it silently and take another deep breath.",
+      "Open your eyes and begin your next task with that boundary.",
+    ],
+  },
+];
+
+export function getProtocol(id: string): Protocol | undefined {
+  return PROTOCOLS.find((p) => p.id === id);
+}
+
+export function getProtocolsByCategory(
+  category: ProtocolCategory,
+): Protocol[] {
+  return PROTOCOLS.filter((p) => p.category === category);
+}
+
+export const ALL_CATEGORIES: ProtocolCategory[] = [
+  "breathing",
+  "movement",
+  "mindset",
+  "sensory",
+  "social",
+];


### PR DESCRIPTION
## Summary
- Add 15 hardcoded protocols across 5 categories (Breathing, Movement, Mindset, Sensory, Social) with types and helpers in `src/lib/protocols.ts`
- Add protocol picker component with category filter chips and selectable card grid
- Wire protocol selection into step 3: user picks a protocol, sees its steps/instructions, then runs the 2-min timer and rates afterward
- Add `protocol_selected` analytics event

Closes #10

## Test plan
- [ ] `/switch` redirects to `/switch/1`
- [ ] `/switch/1`, `/switch/2`, `/switch/3` all render correctly
- [ ] Step 3 shows the protocol picker with category filter buttons
- [ ] Clicking a category filters the grid to matching protocols
- [ ] Clicking a protocol card selects it (highlighted state)
- [ ] Selected protocol shows title, summary, and numbered steps below the picker
- [ ] Timer and after-rating appear only after selecting a protocol
- [ ] Timer start/pause/reset still work as expected
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)