### PR TITLE
[Feature] Stripe Checkout subscription €9/mo + 7-day trial

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@supabase/supabase-js": "^2.95.3",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "stripe": "^20.3.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -6071,6 +6072,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.3.1.tgz",
+      "integrity": "sha512-k990yOT5G5rhX3XluRPw5Y8RLdJDW4dzQ29wWT66piHrbnM2KyamJ1dKgPsw4HzGHRWjDiSSdcI2WdxQUPV3aQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/node": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@supabase/supabase-js": "^2.95.3",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "stripe": "^20.3.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,0 +1,67 @@
+import Stripe from "stripe";
+import { NextRequest, NextResponse } from "next/server";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+
+export async function POST(req: NextRequest) {
+  const body = await req.text();
+  const sig = req.headers.get("stripe-signature");
+
+  if (!sig) {
+    console.error("[stripe-webhook] Missing stripe-signature header");
+    return NextResponse.json({ error: "Missing signature" }, { status: 400 });
+  }
+
+  let event: Stripe.Event;
+
+  try {
+    event = stripe.webhooks.constructEvent(
+      body,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET!,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error(`[stripe-webhook] Signature verification failed: ${message}`);
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  switch (event.type) {
+    case "checkout.session.completed": {
+      const session = event.data.object as Stripe.Checkout.Session;
+      console.log(
+        `[stripe-webhook] checkout.session.completed — session=${session.id} customer=${session.customer} subscription=${session.subscription}`,
+      );
+      break;
+    }
+
+    case "customer.subscription.created": {
+      const sub = event.data.object as Stripe.Subscription;
+      console.log(
+        `[stripe-webhook] customer.subscription.created — sub=${sub.id} customer=${sub.customer} status=${sub.status}`,
+      );
+      break;
+    }
+
+    case "customer.subscription.updated": {
+      const sub = event.data.object as Stripe.Subscription;
+      console.log(
+        `[stripe-webhook] customer.subscription.updated — sub=${sub.id} customer=${sub.customer} status=${sub.status}`,
+      );
+      break;
+    }
+
+    case "customer.subscription.deleted": {
+      const sub = event.data.object as Stripe.Subscription;
+      console.log(
+        `[stripe-webhook] customer.subscription.deleted — sub=${sub.id} customer=${sub.customer} status=${sub.status}`,
+      );
+      break;
+    }
+
+    default:
+      console.log(`[stripe-webhook] Unhandled event type: ${event.type}`);
+  }
+
+  return NextResponse.json({ received: true });
+}


### PR DESCRIPTION
What changed
	•	Added a local Stripe webhook endpoint for dev testing: POST /api/stripe/webhook
	•	Implemented Stripe signature verification using STRIPE_WEBHOOK_SECRET (raw body via req.text())
	•	Logged relevant IDs for key subscription lifecycle events:
	•	checkout.session.completed
	•	customer.subscription.created
	•	customer.subscription.updated
	•	customer.subscription.deleted
	•	Added stripe dependency to the project (package.json / package-lock.json)

Why
	•	We need a reliable local webhook receiver to validate the Stripe integration flow end-to-end before wiring Checkout + subscription state into the app.
	•	This unblocks implementing the paywall rules (trial/subscribed/expired) based on Stripe events.

How to test (local)
	1.	Start the app:
	•	npm run dev
	2.	Start Stripe CLI listener (forwards webhooks to local):
	•	stripe listen --forward-to http://127.0.0.1:3000/api/stripe/webhook
	3.	Trigger a test event:
	•	stripe trigger checkout.session.completed
	•	(optional) stripe trigger customer.subscription.created
	•	(optional) stripe trigger customer.subscription.updated
	•	(optional) stripe trigger customer.subscription.deleted

Verify
	•	Stripe CLI shows 200 responses (not 404/400)
	•	Next.js dev server logs include webhook event names + IDs (session/subscription/customer)

Screens / Notes
	•	This PR is intentionally local-only wiring via Stripe CLI (no public webhook URL yet).
	•	No production webhook destination configured in Stripe dashboard in this PR.

Checklist
	•	Acceptance criteria met
	•	No scope creep (webhook only; no checkout UI)
	•	No secrets committed (.env.local stays local)

Closes #8