### PR TITLE
Paywall rules: 1 free session then paywall (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,20 @@ npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+## Database setup
+
+Migrations live in `supabase/migrations/`. Run them once against your Supabase
+project before starting the dev server.
+
+**Supabase CLI**
+
+```bash
+supabase db push
+```
+
+**No CLI?** Paste each `.sql` file from `supabase/migrations/` into the
+[Supabase SQL editor](https://supabase.com/dashboard) in filename order.
+
+See [`docs/ops/runbook.md`](docs/ops/runbook.md) for the full migration index
+and the paywall/entitlements testing checklist.

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -1,1 +1,71 @@
+# Ops Runbook
 
+## Database migrations
+
+Migrations live in `supabase/migrations/` and are plain SQL files with a
+`YYYYMMDD_<slug>.sql` name prefix so they sort chronologically.
+
+### Running migrations
+
+**Option A — Supabase CLI (recommended for CI / team)**
+
+```bash
+# link once per machine (uses the project ref from supabase/config.toml or --project-ref flag)
+supabase db push
+```
+
+**Option B — Supabase dashboard SQL editor (quick / no CLI needed)**
+
+Paste each file in `supabase/migrations/` into the SQL editor in order and run.
+
+---
+
+### Migration index
+
+| File | Purpose |
+|------|---------|
+| `20260218_add_free_session_used.sql` | Adds `free_session_used boolean NOT NULL DEFAULT false` to `public.profiles`. Tracks whether a free user has consumed their one complimentary session. |
+| `20260218_add_profiles_update_policy.sql` | RLS `UPDATE` policy — `"Users can update own profile"` — so authenticated users can write to their own `profiles` row (required for marking `free_session_used = true`). Idempotent. |
+
+---
+
+## Paywall / entitlements — local testing checklist
+
+After running both migrations above:
+
+1. **Paid user flow**
+   - Set `subscription_status = 'trialing'` (or `'active'`) on a test profile row.
+   - Navigate to `/switch/1` — should load with no redirect.
+
+2. **Free user — first session allowed**
+   - Ensure `subscription_status = 'none'` and `free_session_used = false`.
+   - Complete the full flow: step 1 (before-rating) → step 2 → step 3 (protocol + after-rating).
+   - After selecting the after-rating, `profiles.free_session_used` flips to `true` (verify in Supabase table editor).
+
+3. **Free user — blocked after session used**
+   - With `free_session_used = true` and no active subscription, navigate to `/switch/1`.
+   - Should redirect to `/paywall?next=%2Fswitch%2F1`.
+   - Browser console shows `[analytics] paywall_gate_triggered`.
+
+4. **Unauthenticated user**
+   - Log out, navigate to `/switch/2`.
+   - Should redirect to `/login?next=%2Fswitch%2F2`.
+
+> **If `free_session_used` is not updating:** confirm the RLS UPDATE policy exists.
+> Run `select * from pg_policies where tablename = 'profiles';` in the SQL editor.
+> If the `"Users can update own profile"` row is missing, run
+> `supabase/migrations/20260218_add_profiles_update_policy.sql` manually.
+
+---
+
+## Stripe webhooks (local)
+
+```bash
+stripe listen --forward-to localhost:3000/api/stripe/webhook
+```
+
+Trigger a test subscription event:
+
+```bash
+stripe trigger customer.subscription.created
+```

--- a/src/app/switch/[step]/auth-gate.tsx
+++ b/src/app/switch/[step]/auth-gate.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
+import { fetchProfile, canStartSession } from "@/lib/entitlements";
+import { logEvent } from "@/lib/analytics";
 
 export default function AuthGate({ children }: { children: React.ReactNode }) {
   const [ready, setReady] = useState(false);
@@ -17,11 +19,25 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
         window.location.href = `/login?next=${next}`;
       };
 
+      const redirectToPaywall = () => {
+        logEvent("paywall_gate_triggered", { from: pathname });
+        const next = encodeURIComponent(pathname);
+        window.location.href = `/paywall?next=${next}`;
+      };
+
       try {
         const { data, error } = await supabase.auth.getSession();
 
         if (error || !data.session) {
           redirectToLogin();
+          return;
+        }
+
+        // Check entitlements: paid users pass through; free users get one session.
+        const profile = await fetchProfile();
+
+        if (!profile || !canStartSession(profile)) {
+          redirectToPaywall();
           return;
         }
 

--- a/src/app/switch/[step]/auth-gate.tsx
+++ b/src/app/switch/[step]/auth-gate.tsx
@@ -20,7 +20,11 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
       };
 
       const redirectToPaywall = () => {
-        logEvent("paywall_gate_triggered", { from: pathname });
+        try {
+          logEvent("paywall_gate_triggered", { from: pathname });
+        } catch {
+          // analytics must never block the redirect
+        }
         const next = encodeURIComponent(pathname);
         window.location.href = `/paywall?next=${next}`;
       };

--- a/src/app/switch/[step]/page.tsx
+++ b/src/app/switch/[step]/page.tsx
@@ -101,9 +101,12 @@ export default async function StepPage({
           </Link>
         )}
         {isLast ? (
-          <span className="rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-500">
-            Done (coming soon)
-          </span>
+          <Link
+            href="/"
+            className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+          >
+            Done
+          </Link>
         ) : (
           <Link
             href={`/switch/${stepNum + 1}`}

--- a/src/app/switch/[step]/protocol-step.tsx
+++ b/src/app/switch/[step]/protocol-step.tsx
@@ -1,13 +1,26 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import type { Protocol } from "@/lib/protocols";
 import ProtocolPicker from "./protocol-picker";
 import ProtocolTimer from "./protocol-timer";
 import RatingInput from "./rating-input";
+import { markFreeSessionUsed } from "@/lib/entitlements";
+import { logEvent } from "@/lib/analytics";
+import { logError } from "@/lib/error";
 
 export default function ProtocolStep() {
   const [selected, setSelected] = useState<Protocol | null>(null);
+
+  const handleAfterRating = useCallback(async () => {
+    try {
+      logEvent("session_completed");
+      // Mark the free session used. No-op for paid users / already-used profiles.
+      await markFreeSessionUsed();
+    } catch (err) {
+      logError("ProtocolStep.handleAfterRating", err);
+    }
+  }, []);
 
   return (
     <div className="flex flex-col gap-8">
@@ -36,7 +49,11 @@ export default function ProtocolStep() {
 
           <ProtocolTimer />
 
-          <RatingInput kind="after" label="How do you feel now? (after)" />
+          <RatingInput
+            kind="after"
+            label="How do you feel now? (after)"
+            onSelect={handleAfterRating}
+          />
         </>
       )}
     </div>

--- a/src/app/switch/[step]/rating-input.tsx
+++ b/src/app/switch/[step]/rating-input.tsx
@@ -8,9 +8,12 @@ import { logError } from "@/lib/error";
 export default function RatingInput({
   kind,
   label,
+  onSelect,
 }: {
   kind: RatingKind;
   label: string;
+  /** Optional callback fired after a rating is stored. */
+  onSelect?: (value: number) => void;
 }) {
   const [value, setValue] = useState<number | null>(null);
 
@@ -25,6 +28,7 @@ export default function RatingInput({
       logEvent(kind === "before" ? "before_rating_set" : "after_rating_set", {
         value: n,
       });
+      onSelect?.(n);
     } catch (err) {
       logError("RatingInput.handleSelect", err);
     }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -9,7 +9,9 @@ type EventName =
   | "timer_complete"
   | "protocol_selected"
   | "paywall_viewed"
-  | "checkout_clicked";
+  | "checkout_clicked"
+  | "paywall_gate_triggered"
+  | "session_completed";
 
 export function logEvent(
   name: EventName,

--- a/src/lib/entitlements.ts
+++ b/src/lib/entitlements.ts
@@ -1,0 +1,76 @@
+// src/lib/entitlements.ts
+// Single source of truth for access rules.
+// All functions run client-side using the anon Supabase client so RLS applies.
+
+import { supabase } from "@/lib/supabaseClient";
+
+export type SubscriptionStatus =
+  | "none"
+  | "trialing"
+  | "active"
+  | "past_due"
+  | "canceled";
+
+export interface UserProfile {
+  subscription_status: SubscriptionStatus;
+  current_period_end: string | null;
+  free_session_used: boolean;
+}
+
+/** Fetch the current user's profile row. Returns null if not found or unauthenticated. */
+export async function fetchProfile(): Promise<UserProfile | null> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) return null;
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("subscription_status, current_period_end, free_session_used")
+    .eq("id", session.user.id)
+    .single();
+
+  if (error || !data) return null;
+
+  return data as UserProfile;
+}
+
+/** True when the user has an active paid/trialing subscription. */
+export function isPaidUser(profile: UserProfile): boolean {
+  return (
+    profile.subscription_status === "trialing" ||
+    profile.subscription_status === "active"
+  );
+}
+
+/**
+ * Determine whether the current user may start (or continue) a session.
+ *
+ * Rules:
+ *  - Paid (trialing | active) → always allowed.
+ *  - Free, session not yet used → allowed (one free session).
+ *  - Free, session already used → blocked.
+ */
+export function canStartSession(profile: UserProfile): boolean {
+  if (isPaidUser(profile)) return true;
+  return !profile.free_session_used;
+}
+
+/**
+ * Mark the free session as consumed for the authenticated user.
+ * No-op if already set to avoid redundant writes.
+ */
+export async function markFreeSessionUsed(): Promise<void> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) return;
+
+  await supabase
+    .from("profiles")
+    .update({ free_session_used: true })
+    .eq("id", session.user.id)
+    .eq("free_session_used", false); // only write if not already set
+}

--- a/supabase/migrations/20260218_add_free_session_used.sql
+++ b/supabase/migrations/20260218_add_free_session_used.sql
@@ -1,0 +1,5 @@
+-- Add free_session_used flag to profiles.
+-- Tracks whether a free (non-subscribed) user has completed their one allowed session.
+-- Default false so existing rows are unaffected.
+alter table public.profiles
+  add column if not exists free_session_used boolean not null default false;

--- a/supabase/migrations/20260218_add_profiles_update_policy.sql
+++ b/supabase/migrations/20260218_add_profiles_update_policy.sql
@@ -1,0 +1,25 @@
+-- Allow each authenticated user to update their own row in public.profiles.
+-- Required for: marking free_session_used = true after a free session completes.
+--
+-- Idempotent: the DO $$ block checks pg_policies first so re-running this
+-- migration (e.g. via `supabase db reset`) never raises a duplicate-policy error.
+
+do $$
+begin
+  if not exists (
+    select 1
+    from   pg_policies
+    where  schemaname = 'public'
+      and  tablename  = 'profiles'
+      and  policyname = 'Users can update own profile'
+  ) then
+    execute $policy$
+      create policy "Users can update own profile"
+        on public.profiles
+        for update
+        using      (auth.uid() = id)
+        with check (auth.uid() = id)
+    $policy$;
+  end if;
+end;
+$$;


### PR DESCRIPTION
Fixes #9

Implements MVP paywall entitlement rules:
	•	Trialing/active users: unlimited sessions
	•	Free users: 1 full session, then redirect to /paywall?next=…
	•	Marks free_session_used on completion and logs paywall/session analytics

DB:
	•	Adds free_session_used column migration
	•	Adds RLS UPDATE policy migration for profiles (users can update their own row)

Tested:
	•	Paid user flow (trialing) can access /switch/*
	•	Free user first session flips free_session_used=true
	•	Free user second attempt redirects to /paywall with next param